### PR TITLE
Allow creation of widgets with json format

### DIFF
--- a/rename.json
+++ b/rename.json
@@ -11,5 +11,8 @@
     "typings/MashupPlatform/MashupPlatform-tests.ts": "{% if (!js) { %}typings/MashupPlatform/MashupPlatform-tests.ts{% }%}",
     "typings/MashupPlatform/tsconfig.json": "{% if (!js) { %}typings/MashupPlatform/tsconfig.json{% }%}",
     "typings/NGSI/NGSI.d.ts": "{% if (!js && ngsi) { %}typings/NGSI/NGSI.d.ts{% }%}",
-    "typings/NGSI/NGSI-tests.ts": "{% if (!js && ngsi) { %}typings/NGSI/NGSI-tests.ts{% }%}"
+    "typings/NGSI/NGSI-tests.ts": "{% if (!js && ngsi) { %}typings/NGSI/NGSI-tests.ts{% }%}",
+
+    "src/config.xml": "{% if (!json) { %}src/config.xml{% }%}",
+    "src/config.json": "{% if (json) { %}src/config.json{% }%}"
 }

--- a/root/Gruntfile.js
+++ b/root/Gruntfile.js
@@ -7,7 +7,7 @@
  */
 
 var ConfigParser = require('wirecloud-config-parser');
-var parser = new ConfigParser('src/config.xml');
+var parser = new ConfigParser('src/{% if (json) { %}config.json{% } else { %}config.xml{% } %}');
 
 module.exports = function (grunt) {
 
@@ -103,8 +103,9 @@ module.exports = function (grunt) {
                             'css/**/*',
                             'doc/**/*',
                             'images/**/*',{% if(!js) { %}
-                            'ts/**/*',{% }%}
-                            'config.xml'
+                            'ts/**/*',{% }%}{% if (json) { %}
+                            "config.json",{% } else { %}
+                            "config.xml", {% } %}
                         ]
                     },
                     {

--- a/root/src/config.json
+++ b/root/src/config.json
@@ -1,0 +1,39 @@
+{
+    "authors": [
+        {
+            "email": "{%= author_email %}",
+            "name": "{%= author_name %}"
+        }
+    ],
+    "changelog": "doc/changelog.md",
+    "default_lang": "en",
+    "description": "{%= description %}",
+    "doc": "doc/userguide.md",
+    "email": "wirecloud@conwet.com",
+    "homepage": "{%= homepage %}",
+    "image": "",
+    "smartphoneimage": "",
+    "issuetracker": "{%= bugs %}",
+    "js_files": [
+        "js/main.js"
+    ],
+    "license": "{%= licenses %}",
+    "longdescription": "DESCRIPTION.md",
+    "name": "{%= name %}",
+    "preferences": [],
+    "properties": [],
+    "requirements": [
+        {% if (ngsi) { %}
+        {
+            "name": "NGSI"
+        }
+        {% } %}
+    ],
+    "title": "{%= project_name %}",
+    "translations": {},
+    "type": "operator",
+    "vendor": "{%= vendor %}",
+    "version": "{%= version %}",
+    "wiring": {
+    }
+}

--- a/template.js
+++ b/template.js
@@ -72,6 +72,14 @@ exports.template = function(grunt, init, done) {
         //     warning: "Valid options: \"grunt\""
         // },
         {
+            name: "json",
+            message: "Will the widget save its configuration in json (recommended) or in xml (soon to be deprecated)?",
+            default: "json",
+            validator: /(json|xml)/i,
+            sanitize: sanitizeComparer(/json/i),
+            warning: "Valid options: \"json\" for JSON or \"xml\" for XML"
+        },
+        {
             name: "jquery",
             message: "Will the project use jquery?",
             default: "y/N",
@@ -194,7 +202,12 @@ exports.template = function(grunt, init, done) {
 
         // Write package.json :)
         var nobj = {};
-        nobj.description = "This package.json file is only used for installing npm dependencies. But this is not an installable node package, but a WireCloud operator. Take a look into src/config.xml for more details about this operator"
+        if (props.json) {
+            nobj.description = "This package.json file is only used for installing npm dependencies. But this is not an installable node package, but a WireCloud widget. Take a look into src/config.json for more details about this widget";
+        }
+        else {
+            nobj.description = "This package.json file is only used for installing npm dependencies. But this is not an installable node package, but a WireCloud widget. Take a look into src/config.xml for more details about this widget";
+        }
         nobj.devDependencies = devDependencies;
         init.writePackageJSON('package.json', nobj, function(pkg, props) {
             pkg.private = true;


### PR DESCRIPTION
This PR allows the creation of a new project that defines its properties on a config.json file instead of a config.xml one
Equivalent of https://github.com/Wirecloud/grunt-init-wirecloud-widget/pull/2