### PR TITLE
Use new way of loading v2 operators

### DIFF
--- a/root/src/config.json
+++ b/root/src/config.json
@@ -18,7 +18,6 @@
     "js_files": [
         "js/main.js"
     ],
-    "entrypoint": "{%= entrypoint %}",
     "license": "{%= licenses %}",
     "longdescription": "DESCRIPTION.md",
     "name": "{%= name %}",

--- a/root/src/config.xml
+++ b/root/src/config.xml
@@ -34,6 +34,4 @@
         <script src="js/main.js"/>
     </scripts>
 
-    <entrypoint name="{%= entrypoint %}" />
-
 </operator>

--- a/root/src/js/main.js
+++ b/root/src/js/main.js
@@ -6,6 +6,8 @@
  * Licensed under the {%= licenses.join(', ') %} license{%= licenses.length === 1 ? '' : 's' %}.
  */
 
+/* global Wirecloud */
+
 (function (script) {
 
     "use strict";
@@ -20,7 +22,12 @@
         }
     }
 
-    Wirecloud.registerOperatorClass(script, Operator);
+    if (!('Wirecloud') in window) {
+        // For testing purposes
+        window.Operator = Operator;
+    } else {
+        Wirecloud.registerOperatorClass(script, Operator);
+    }
 
     /* test-code */
 

--- a/root/src/js/main.js
+++ b/root/src/js/main.js
@@ -22,7 +22,7 @@
         }
     }
 
-    if (!('Wirecloud') in window) {
+    if (!('Wirecloud' in window)) {
         // For testing purposes
         window.Operator = Operator;
     } else {

--- a/root/src/js/main.js
+++ b/root/src/js/main.js
@@ -6,13 +6,11 @@
  * Licensed under the {%= licenses.join(', ') %} license{%= licenses.length === 1 ? '' : 's' %}.
  */
 
-/* exported {%= entrypoint %} */
-
-(function () {
+(function (script) {
 
     "use strict";
 
-    class {%= entrypoint %} {
+    class Operator {
         constructor(MashupPlatform, extra) {
             this.MashupPlatform = MashupPlatform;
 
@@ -22,11 +20,10 @@
         }
     }
 
-    // We define the class as part of the window object so that it can be instantiated by Wirecloud
-    window.{%= entrypoint %} = {%= entrypoint %};
+    Wirecloud.registerOperatorClass(script, Operator);
 
     /* test-code */
 
     /* end-test-code */
 
-})();
+})(document.currentScript);

--- a/root/src/ts/main.ts
+++ b/root/src/ts/main.ts
@@ -32,4 +32,4 @@ export class Operator {
     }
 }
 
-(<any>window).registerOperatorClass((<any>document).currentScript, Operator);
+(<any>window).Wirecloud.registerOperatorClass((<any>document).currentScript, Operator);

--- a/root/src/ts/main.ts
+++ b/root/src/ts/main.ts
@@ -16,7 +16,7 @@ import MashupPlatform = require("MashupPlatform");
 {% if (ngsi) { %}import NGSI = require("NGSI");{% }%}
 /* end-import-block */
 
-export class {%= entrypoint %} {
+export class Operator {
     private MashupPlatform: MashupPlatform;
     {% if (ngsi) { %}private NGSI: NGSI;{% }%}
 
@@ -32,5 +32,4 @@ export class {%= entrypoint %} {
     }
 }
 
-// We define the class as part of the window object so that it can be instantiated by Wirecloud
-(<any>window)["{%= entrypoint %}"] = {%= entrypoint %};
+(<any>window).registerOperatorClass((<any>document).currentScript, Operator);

--- a/template.js
+++ b/template.js
@@ -44,14 +44,6 @@ var capitalizeAndRemoveUnderscore = function capitalizeAndRemoveUnderscore(old) 
     return t.charAt(0).toUpperCase() + t.slice(1);
 };
 
-var getEntrypointName = function getEntrypointName(vendor, name, version) {
-    // Remove all non-alphanumeric characters. Replace spaces with underscores.
-    vendor = vendor.replace(/[^a-zA-Z0-9]/g, '').replace(/\s/g, '_');
-    name = name.replace(/[^a-zA-Z0-9]/g, '').replace(/\s/g, '_');
-    version = version.replace(/[^a-zA-Z0-9]/g, '').replace(/\s/g, '_');
-    return vendor + '_' + name + '_' + version;
-}
-
 // The actual init template.
 exports.template = function(grunt, init, done) {
     init.process([
@@ -132,7 +124,6 @@ exports.template = function(grunt, init, done) {
     ], function(err, props){
         var exportsOverride = {};
         props.jsname = capitalizeAndRemoveUnderscore(props.name);
-        props.entrypoint = getEntrypointName(props.vendor, props.name, props.version);
         props.bower = props.jquery; // Change way to determine bower?
         props.ngsi = false; // ??
         var bowerdeps = {};

--- a/template.js
+++ b/template.js
@@ -44,11 +44,12 @@ var capitalizeAndRemoveUnderscore = function capitalizeAndRemoveUnderscore(old) 
     return t.charAt(0).toUpperCase() + t.slice(1);
 };
 
-var getEntrypointName = function getEntrypointName(vendor, name) {
+var getEntrypointName = function getEntrypointName(vendor, name, version) {
     // Remove all non-alphanumeric characters. Replace spaces with underscores.
     vendor = vendor.replace(/[^a-zA-Z0-9]/g, '').replace(/\s/g, '_');
     name = name.replace(/[^a-zA-Z0-9]/g, '').replace(/\s/g, '_');
-    return vendor + '_' + name;
+    version = version.replace(/[^a-zA-Z0-9]/g, '').replace(/\s/g, '_');
+    return vendor + '_' + name + '_' + version;
 }
 
 // The actual init template.
@@ -131,7 +132,7 @@ exports.template = function(grunt, init, done) {
     ], function(err, props){
         var exportsOverride = {};
         props.jsname = capitalizeAndRemoveUnderscore(props.name);
-        props.entrypoint = getEntrypointName(props.vendor, props.name);
+        props.entrypoint = getEntrypointName(props.vendor, props.name, props.version);
         props.bower = props.jquery; // Change way to determine bower?
         props.ngsi = false; // ??
         var bowerdeps = {};


### PR DESCRIPTION
Uses the new `registerOperatorClass` function to load v2 operators. To be merged after https://github.com/Wirecloud/wirecloud/pull/542.